### PR TITLE
bricks: change argument enum side side to enum side from

### DIFF
--- a/packetgraph/bricks/bricks.c
+++ b/packetgraph/bricks/bricks.c
@@ -520,15 +520,15 @@ void brick_generic_unlink(struct brick *brick, struct switch_error **errp)
  * function.
  */
 
-inline int brick_burst(struct brick *brick, enum side side,
+inline int brick_burst(struct brick *brick, enum side from,
 		       uint16_t edge_index, struct rte_mbuf **pkts, uint16_t nb,
 		       uint64_t pkts_mask, struct switch_error **errp)
 {
 	/* @side is the opposite side of the direction on which
 	 * we send the packets, so we flip it */
-	rte_atomic64_add(&brick->sides[flip_side(side)].packet_count,
+	rte_atomic64_add(&brick->sides[flip_side(from)].packet_count,
 			 mask_count(pkts_mask));
-	return brick->burst(brick, side, edge_index, pkts, nb, pkts_mask, errp);
+	return brick->burst(brick, from, edge_index, pkts, nb, pkts_mask, errp);
 }
 
 inline int brick_burst_to_east(struct brick *brick, uint16_t edge_index,
@@ -598,7 +598,7 @@ struct rte_mbuf **brick_east_burst_get(struct brick *brick,
 	return brick->burst_get(brick, EAST_SIDE, pkts_mask);
 }
 
-int brick_side_forward(struct brick_side *brick_side, enum side side,
+int brick_side_forward(struct brick_side *brick_side, enum side from,
 		       struct rte_mbuf **pkts, uint16_t nb,
 		       uint64_t pkts_mask, struct switch_error **errp)
 {
@@ -607,7 +607,7 @@ int brick_side_forward(struct brick_side *brick_side, enum side side,
 
 	for (i = 0; i < brick_side->max; i++) {
 		if (brick_side->edges[i].link)
-			ret = brick_burst(brick_side->edges[i].link, side,
+			ret = brick_burst(brick_side->edges[i].link, from,
 					  brick_side->edges[i].pair_index,
 					  pkts, nb, pkts_mask, errp);
 		if (unlikely(!ret))

--- a/packetgraph/bricks/collect-brick.c
+++ b/packetgraph/bricks/collect-brick.c
@@ -30,7 +30,7 @@ struct collect_state {
 	uint64_t pkts_mask[MAX_SIDE];
 };
 
-static int collect_burst(struct brick *brick, enum side side,
+static int collect_burst(struct brick *brick, enum side from,
 			 uint16_t edge_index, struct rte_mbuf **pkts,
 			 uint16_t nb, uint64_t pkts_mask,
 			 struct switch_error **errp)
@@ -44,14 +44,14 @@ static int collect_burst(struct brick *brick, enum side side,
 		return 0;
 	}
 
-	if (state->pkts_mask[side])
-		packets_free(state->pkts[side], state->pkts_mask[side]);
+	if (state->pkts_mask[from])
+		packets_free(state->pkts[from], state->pkts_mask[from]);
 
-	state->pkts_mask[side] = pkts_mask;
+	state->pkts_mask[from] = pkts_mask;
 	/* We made sure nb <= MAX_PKTS_BURST */
 	/* Flawfinder: ignore */
-	memcpy(state->pkts[side], pkts, nb * sizeof(struct rte_mbuf *));
-	packets_incref(state->pkts[side], state->pkts_mask[side]);
+	memcpy(state->pkts[from], pkts, nb * sizeof(struct rte_mbuf *));
+	packets_incref(state->pkts[from], state->pkts_mask[from]);
 
 	return 1;
 }

--- a/packetgraph/bricks/diode-brick.c
+++ b/packetgraph/bricks/diode-brick.c
@@ -22,17 +22,17 @@ struct diode_state {
 	enum side output;
 };
 
-static int diode_burst(struct brick *brick, enum side side, uint16_t edge_index,
+static int diode_burst(struct brick *brick, enum side from, uint16_t edge_index,
 		       struct rte_mbuf **pkts, uint16_t nb, uint64_t pkts_mask,
 		       struct switch_error **errp)
 {
 	struct diode_state *state = brick_get_state(brick, struct diode_state);
-	struct brick_side *s = &brick->sides[flip_side(side)];
+	struct brick_side *s = &brick->sides[flip_side(from)];
 
-	if (state->output == side)
+	if (state->output == from)
 		return 1;
 
-	return brick_side_forward(s, side, pkts, nb, pkts_mask, errp);
+	return brick_side_forward(s, from, pkts, nb, pkts_mask, errp);
 }
 
 static int diode_init(struct brick *brick,

--- a/packetgraph/bricks/hub-brick.c
+++ b/packetgraph/bricks/hub-brick.c
@@ -21,7 +21,7 @@ struct hub_state {
 	struct brick brick;
 };
 
-static int hub_burst(struct brick *brick, enum side side, uint16_t edge_index,
+static int hub_burst(struct brick *brick, enum side from, uint16_t edge_index,
 		     struct rte_mbuf **pkts, uint16_t nb, uint64_t pkts_mask,
 		     struct switch_error **errp)
 {
@@ -35,7 +35,7 @@ static int hub_burst(struct brick *brick, enum side side, uint16_t edge_index,
 		for (j = 0; j < s->max; j++) {
 			if (!s->edges[j].link)
 				continue;
-			if (side == i && j == edge_index)
+			if (from == i && j == edge_index)
 				continue;
 			ret = brick_burst(s->edges[j].link, flip_side(i),
 					  s->edges[j].pair_index,

--- a/packetgraph/bricks/nop-brick.c
+++ b/packetgraph/bricks/nop-brick.c
@@ -24,13 +24,13 @@ struct nop_state {
 
 /* The fastpath data function of the nop_brick just forward the bursts */
 
-static int nop_burst(struct brick *brick, enum side side, uint16_t edge_index,
+static int nop_burst(struct brick *brick, enum side from, uint16_t edge_index,
 		     struct rte_mbuf **pkts, uint16_t nb, uint64_t pkts_mask,
 		     struct switch_error **errp)
 {
-	struct brick_side *s = &brick->sides[flip_side(side)];
+	struct brick_side *s = &brick->sides[flip_side(from)];
 
-	return brick_side_forward(s, side, pkts, nb, pkts_mask, errp);
+	return brick_side_forward(s, from, pkts, nb, pkts_mask, errp);
 }
 
 static int nop_init(struct brick *brick, struct brick_config *config,

--- a/packetgraph/bricks/switch-brick.c
+++ b/packetgraph/bricks/switch-brick.c
@@ -35,7 +35,7 @@
 struct address_source {
 	uint64_t unlink;	/* hot plugging unlink */
 	uint16_t edge_index;    /* index of the port the packet came from */
-	enum side side;		/* side of the switch the packet came from */
+	enum side from;		/* side of the switch the packet came from */
 };
 
 /* structure used to describe a side (EAST_SIDE/WEST_SIDE) of the switch */
@@ -104,7 +104,7 @@ static int forward_bursts(struct switch_state *state,
 			  struct rte_mbuf **pkts, uint16_t nb,
 			  struct switch_error **errp)
 {
-	struct switch_side *switch_side = &state->sides[source->side];
+	struct switch_side *switch_side = &state->sides[source->from];
 	enum side i;
 	uint16_t j;
 	int ret;
@@ -223,7 +223,7 @@ static void do_switch(struct switch_state *state,
 		struct switch_side *switch_side;
 		struct address_source *entry;
 		uint16_t edge_index;
-		enum side side;
+		enum side from;
 		uint64_t bit;
 		uint16_t i;
 
@@ -231,8 +231,8 @@ static void do_switch(struct switch_state *state,
 
 		entry = entries[i];
 
-		side = entry->side;
-		switch_side = &state->sides[side];
+		from = entry->from;
+		switch_side = &state->sides[from];
 		edge_index = entry->edge_index;
 
 		/* the lookup table entry is stale due to a port hotplug */
@@ -323,7 +323,7 @@ static void clear_hash_keys(struct rte_mbuf **pkts, uint64_t pkts_mask)
 	}
 }
 
-static int switch_burst(struct brick *brick, enum side side,
+static int switch_burst(struct brick *brick, enum side from,
 			uint16_t edge_index, struct rte_mbuf **pkts,
 			uint16_t nb, uint64_t pkts_mask,
 			struct switch_error **errp)
@@ -335,9 +335,9 @@ static int switch_burst(struct brick *brick, enum side side,
 	struct address_source source;
 	int ret;
 
-	source.side = side;
+	source.from = from;
 	source.edge_index = edge_index;
-	source.unlink = state->sides[side].unlinks[edge_index];
+	source.unlink = state->sides[from].unlinks[edge_index];
 
 	prefetch_packets(pkts, pkts_mask);
 

--- a/packetgraph/bricks/vhost-user-brick.c
+++ b/packetgraph/bricks/vhost-user-brick.c
@@ -62,7 +62,7 @@ static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static pthread_t vhost_session_thread;
 
-static int vhost_burst(struct brick *brick, enum side side, uint16_t edge_index,
+static int vhost_burst(struct brick *brick, enum side from, uint16_t edge_index,
 		       struct rte_mbuf **pkts, uint16_t nb, uint64_t pkts_mask,
 		       struct switch_error **errp)
 {
@@ -70,7 +70,7 @@ static int vhost_burst(struct brick *brick, enum side side, uint16_t edge_index,
 	struct virtio_net *virtio_net;
 	uint16_t pkts_count;
 
-	if (state->output == side) {
+	if (state->output == from) {
 		*errp = error_new("Burst packets going on the wrong direction");
 		return 0;
 	}

--- a/packetgraph/include/bricks/brick.h
+++ b/packetgraph/include/bricks/brick.h
@@ -55,7 +55,7 @@ int brick_generic_east_link(struct brick *target,
 void brick_generic_unlink(struct brick *brick, struct switch_error **errp);
 
 /* data flow */
-int brick_burst(struct brick *brick, enum side side, uint16_t edge_index,
+int brick_burst(struct brick *brick, enum side from, uint16_t edge_index,
 		struct rte_mbuf **pkts, uint16_t nb, uint64_t pkts_mask,
 		struct switch_error **errp);
 
@@ -83,7 +83,7 @@ struct rte_mbuf **brick_east_burst_get(struct brick *brick,
 				       uint64_t *pkts_mask,
 				       struct switch_error **errp);
 
-int brick_side_forward(struct brick_side *brick_side, enum side side,
+int brick_side_forward(struct brick_side *brick_side, enum side from,
 		       struct rte_mbuf **pkts, uint16_t nb,
 		       uint64_t pkts_mask, struct switch_error **errp);
 


### PR DESCRIPTION
In brick_burst and similar fonction, the function had an argument
enum side side, which was used to indicate where the packets come from.
This argument is nom call enum side from, because it's more explicit

Signed-off-by: Matthias Gatto matthias.gatto@outscale.com
