### PR TITLE
api/server: fix security group rule checking

### DIFF
--- a/api/server/api_0.cc
+++ b/api/server/api_0.cc
@@ -594,6 +594,10 @@ bool API_0::validate_sg_rule(const MessageV0_Rule &rule) {
             LOG_DEBUG_("bad port range");
             return false;
         }
+        if (port_start > port_end) {
+            LOG_DEBUG_("bad port range (start > end)");
+            return false;
+        }
     }
 
     // CIDR or security group


### PR DESCRIPTION
When a TCP/UDP rule is added, a port range must be defined.
Port range start must not be greater that port range end.
This is not currently a bug as firewall rules building in graph.c
detects this case but API_0::validate_sg_rule() must have checked it
before.

Signed-off-by: Jerome Jutteau <jerome.jutteau@outscale.com>