### PR TITLE
api/server: fix syntax when building firewall rules

### DIFF
--- a/api/server/graph.cc
+++ b/api/server/graph.cc
@@ -562,13 +562,13 @@ std::string Graph::fw_build_rule(const app::Rule &rule) {
     // Build protocol part
     switch (rule.protocol) {
     case IPPROTO_ICMP:
-        r += " and ip proto icmp";
+        r += " and icmp";
         break;
     case IPPROTO_TCP:
-        r += " and ip proto tcp";
+        r += " and tcp";
         break;
     case IPPROTO_UDP:
-        r += " and ip proto udp";
+        r += " and udp";
         break;
     case -1:
         // Allow all


### PR DESCRIPTION
It appears that packetgraph's firewall don't support all pcap filter
syntax.

Signed-off-by: Jerome Jutteau <jerome.jutteau@outscale.com>