### PR TITLE
tests: mask wget output

### DIFF
--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -158,12 +158,12 @@ function download {
 
     if [ ! -f $path ]; then
         echo "$path, let's download it..."
-        wget $url -O $path
+        wget -q $url -O $path || exit 1
     fi
 
     if [ ! "$(md5sum $path | cut -f 1 -d ' ')" == "$md5" ]; then
         echo "Bad md5 for $path, let's download it ..."
-        wget $url -O $path
+        wget -q $url -O $path || exit 1
         if [ ! "$(md5sum $path | cut -f 1 -d ' ')" == "$md5" ]; then
             echo "Still bad md5 for $path ... abort."
             exit 1


### PR DESCRIPTION
When tests scripts output is recorded (e.g. Jenkins), output
is flooded with download progression.

Signed-off-by: Jerome Jutteau <jerome.jutteau@outscale.com>

e.g.

```
10:20:15  75100K .......... .......... .......... .......... ..........  6% 25,5M 37s
10:20:15  75150K .......... .......... .......... .......... ..........  6% 24,0M 37s
10:20:15  75200K .......... .......... .......... .......... ..........  6% 19,9M 37s
10:20:15  75250K .......... .......... .......... .......... ..........  6% 26,3M 37s
10:20:15  75300K .......... .......... .......... .......... ..........  6% 27,7M 37s
10:20:15  75350K .......... .......... .......... .......... ..........  6% 27,7M 37s
10:20:15  75400K .......... .......... .......... .......... ..........  6% 25,1M 37s
10:20:15  75450K .......... .......... .......... .......... ..........  6% 26,3M 37s
10:20:15  75500K .......... .......... .......... .......... ..........  6% 27,1M 37s
10:20:15  75550K .......... .......... .......... .......... ..........  6% 23,4M 37s
10:20:15  75600K .......... .......... .......... .......... ..........  6% 21,2M 37s
10:20:15  75650K .......... .......... .......... .......... ..........  6% 24,1M 37s
10:20:15  75700K .......... .......... .......... .......... ..........  6% 25,4M 37s

...
```