### PR TITLE
tests: remove set -e in function.sh

### DIFF
--- a/scripts/tests_all.sh
+++ b/scripts/tests_all.sh
@@ -21,21 +21,6 @@ echo "Butterfly tests start"
 echo $($BUTTERFLY_BUILD_ROOT/api/server/butterflyd --version)
 echo "############################################################"
 
-# API tests
-$BUTTERFLY_ROOT/scripts/tests_api.sh $BUTTERFLY_BUILD_ROOT $VERBOSE
-if [ $? != 0 ]; then
-    tput setaf 1
-    echo "API test failed"
-    tput setaf 7
-    exit 1
-else
-    tput setaf 2
-    echo "API test OK"
-    tput setaf 7
-fi
-
-sleep 5
-
 # API style test
 $BUTTERFLY_ROOT/scripts/tests_api_style.sh
 if [ $? != 0 ]; then
@@ -46,6 +31,21 @@ if [ $? != 0 ]; then
 else
     tput setaf 2
     echo "API style test OK"
+    tput setaf 7
+fi
+
+sleep 1
+
+# API tests
+$BUTTERFLY_ROOT/scripts/tests_api.sh $BUTTERFLY_BUILD_ROOT $VERBOSE
+if [ $? != 0 ]; then
+    tput setaf 1
+    echo "API test failed"
+    tput setaf 7
+    exit 1
+else
+    tput setaf 2
+    echo "API test OK"
     tput setaf 7
 fi
 

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -1,4 +1,3 @@
-set -e
 IMG_URL=https://osu.eu-west-2.outscale.com/jerome.jutteau/16d1bc0517de5c95aa076a0584b43af6/arch-100816.qcow
 IMG_MD5=1ca000ddbc5ac271c77d1875fab71083
 KEY_URL=https://osu.eu-west-2.outscale.com/jerome.jutteau/16d1bc0517de5c95aa076a0584b43af6/arch-100816.rsa
@@ -42,7 +41,7 @@ function ssh_run_timeout {
     timeout=$2
     cmd="${@:3}"
     key=$BUTTERFLY_BUILD_ROOT/vm.rsa
-    ssh -q -p 500$id -l root -i $key -oStrictHostKeyChecking=no -oConnectTimeout=$timeout 127.0.0.1 $cmd 
+    ssh -q -p 500$id -l root -i $key -oStrictHostKeyChecking=no -oConnectTimeout=$timeout 127.0.0.1 $cmd
 }
 
 function scp_to {
@@ -64,88 +63,76 @@ function ssh_ping_ip {
     id=$1
     src=$2
     dst=$3
-    set +e
+
     ssh_run $id ping -c 1 -W 2 -I $src $dst &> /dev/null
     if [ $? -ne 0 ]; then
-        echo "ping on VM $id: $src ---> $dst FAIL"
-        RETURN_CODE=1
+	fail "ping on VM $id: $src ---> $dst FAIL"
     else
         echo "ping on VM $id: $src ---> $dst OK"
     fi
-    set -e
 }
 
 function ssh_no_ping_ip {
     id=$1
     src=$2
     dst=$3
-    set +e
+
     ssh_run $id ping -c 1 -W 2 -I $src $dst &> /dev/null
     if [ $? -ne 0 ]; then
         echo "ping on VM $id: $src -/-> $dst OK"
     else
-        echo "ping on VM $id: $src -/-> $dst FAIL"
-        RETURN_CODE=1
+	fail "ping on VM $id: $src -/-> $dst FAIL"
     fi
-    set -e
 }
 
 function ssh_ping_ip6 {
     id=$1
     src=$2
     dst=$3
-    set +e
+
     ssh_run $id ping6 -c 1 -W 2 -I $src $dst &> /dev/null
     if [ $? -ne 0 ]; then
-        echo "ping6 on VM $id: $src ---> $dst FAIL"
-        RETURN_CODE=1
+	fail "ping6 on VM $id: $src ---> $dst FAIL"
     else
         echo "ping6 on VM $id: $src ---> $dst OK"
     fi
-    set -e
 }
 
 function ssh_no_ping_ip6 {
     id=$1
     src=$2
     dst=$3
-    set +e
+
     ssh_run $id ping6 -c 1 -W 2 -I $src $dst &> /dev/null
     if [ $? -ne 0 ]; then
         echo "ping on VM $id: $src -/-> $dst OK"
     else
-        echo "ping on VM $id: $src -/-> $dst FAIL"
-        RETURN_CODE=1
+	fail "ping6 on VM $id: $src -/-> $dst FAIL"
     fi
-    set -e
 }
 
 function ssh_ping {
     id1=$1
     id2=$2
-    set +e
+
     ssh_run $id1 ping 42.0.0.$id2 -c 1 -W 2 &> /dev/null
     if [ $? -ne 0 ]; then
-        echo "ping VM $id1 ---> VM $id2 FAIL"
-        RETURN_CODE=1
+        fail "ping VM $id1 ---> VM $id2 FAIL"
     else
         echo "ping VM $id1 ---> VM $id2 OK"
     fi
-    set -e
 }
 
 function ssh_no_ping {
     id1=$1
     id2=$2
-    set +e
+
     ssh_run $id1 ping 42.0.0.$id2 -c 1 -W 2 &> /dev/null
     if [ $? -ne 0 ]; then
         echo "ping VM $id1 -/-> VM $id2 OK"
     else
-        echo "ping VM $id1 -/-> VM $id2 FAIL"
-        RETURN_CODE=1
+        fail "ping VM $id1 -/-> VM $id2 FAIL"
     fi
-    set -e
 }
 
 function ssh_ping6 {
@@ -153,8 +140,7 @@ function ssh_ping6 {
     id2=$2
     ssh_run $id1 ping6 2001:db8:2000:aff0::$id2 -c 1 -W 2 &> /dev/null
     if [ $? -ne 0 ]; then
-        echo "ping6 VM $id1 ---> VM $id2 FAIL"
-        RETURN_CODE=1
+        fail "ping6 VM $id1 ---> VM $id2 FAIL"
     else
         echo "ping6 VM $id1 ---> VM $id2 OK"
     fi
@@ -163,39 +149,35 @@ function ssh_ping6 {
 function ssh_no_ping6 {
     id1=$1
     id2=$2
-    set +e
+
     ssh_run $id1 ping6 2001:db8:2000:aff0::$id2 -c 1 -W 2 &> /dev/null
     if [ $? -ne 0 ]; then
         echo "ping6 VM $id1 -/-> VM $id2 OK"
     else
-        echo "ping6 VM $id1 -/-> VM $id2 FAIL"
-        RETURN_CODE=1
+        fail "ping6 VM $id1 -/-> VM $id2 FAIL"
     fi
-    set -e
 }
 
 function ssh_iperf_tcp {
     id1=$1
     id2=$2
-    set +e
+
     (ssh_run $id1 iperf -s &> /dev/null &)
     local server_pid=$!
     sleep 1
     ssh_run $id2 iperf -c 42.0.0.$id1 -t 3 &> /dev/null
     if [ $? -ne 0 ]; then
-        echo "iperf tcp VM $id1 ---> VM $id2 FAIL"
-        RETURN_CODE=1
+        fail "iperf tcp VM $id1 ---> VM $id2 FAIL"
     else
         echo "iperf tcp VM $id1 ---> VM $id2 OK"
     fi
     kill -9 $server_pid &> /dev/null
-    set -e
 }
 
 function ssh_iperf_udp {
     id1=$1
     id2=$2
-    set +e
+
     (ssh_run $id1 iperf -s -u &> /tmp/iperf_tmp_results &)
     local server_pid=$!
     sleep 1
@@ -203,38 +185,34 @@ function ssh_iperf_udp {
     ret=$?
     res=$(cat /tmp/iperf_tmp_results |grep "%" | cut -d '(' -f 2 | cut -d '%' -f 1)
     if [ $ret -ne 0 ] || [ ".$res" != ".0" ]; then
-        echo "iperf udp VM $id1 ---> VM $id2 FAIL"
-        RETURN_CODE=1
+        fail "iperf udp VM $id1 ---> VM $id2 FAIL"
     else
         echo "iperf udp VM $id1 ---> VM $id2 OK"
     fi
     kill -9 server_pid &> /dev/null
     rm /tmp/iperf_tmp_results
-    set -e
 }
 
 function ssh_iperf3_tcp {
     id1=$1
     id2=$2
-    set +e
+
     (ssh_run $id1 iperf3 -s &> /dev/null &)
     local server_pid=$!
     sleep 1
     ssh_run $id2 iperf3 -c 42.0.0.$id1 -t 3 &> /dev/null
     if [ $? -ne 0 ]; then
-        echo "iperf3 tcp VM $id1 ---> VM $id2 FAIL"
-        RETURN_CODE=1
+        fail "iperf3 tcp VM $id1 ---> VM $id2 FAIL"
     else
         echo "iperf3 tcp VM $id1 ---> VM $id2 OK"
     fi
     kill -9 $server_pid &> /dev/null
-    set -e
 }
 
 function ssh_iperf3_udp {
     id1=$1
     id2=$2
-    set +e
+
     (ssh_run $id1 iperf3 -s &> /dev/null &)
     local server_pid=$!
     sleep 1
@@ -242,14 +220,12 @@ function ssh_iperf3_udp {
     local ret=$?
     local res=$(cat /tmp/iperf3_tmp_results | grep packets | tail -n 1 | cut -d ':' -f 2 | cut -d ',' -f 1 | tr -d ' ' | tr -d '\t')
     if [ $res -eq 0 ] || [ $ret -ne 0 ]; then
-        echo "iperf3 udp VM $id1 ---> VM $id2 FAIL"
-        RETURN_CODE=1
+        fail "iperf3 udp VM $id1 ---> VM $id2 FAIL"
     else
         echo "iperf3 udp VM $id1 ---> VM $id2 OK"
     fi
     kill -9 $server_pid &> /dev/null
     rm /tmp/iperf3_tmp_results
-    set -e
 }
 
 function ssh_connection_tests_internal {
@@ -270,9 +246,7 @@ function ssh_connection_tests_internal {
     elif [ "$protocol" == "sctp" ]; then
         proto_cmd="sctp"
     else
-        echo -e "protocol $protocol not supported by nic_add_port_open"
-        RETURN_CODE=1
-        return $RETURN_CODE
+        fail "protocol $protocol not supported by nic_add_port_open"
     fi
 
     if [ "$proto_cmd" == "sctp" ]; then
@@ -294,11 +268,11 @@ function ssh_connection_tests_internal {
 function ssh_clean_connection {
     id1=$1
     id2=$2
-    
-    ssh_run $id2 "rm /tmp/test" &> /dev/null || true
-    ssh_run $id1 "killall ncat" &> /dev/null || true
-    ssh_run $id2 "killall ncat" &> /dev/null || true
-    ssh_run $id2 "killall sctp_test" &> /dev/null || true
+
+    ssh_run $id2 "rm /tmp/test" &> /dev/null
+    ssh_run $id1 "killall ncat" &> /dev/null
+    ssh_run $id2 "killall ncat" &> /dev/null
+    ssh_run $id2 "killall sctp_test" &> /dev/null
 }
 
 function ssh_connection_test_file {
@@ -335,21 +309,18 @@ function ssh_connection_test {
     id2=$3
     port=$4
 
-    set +e
     ssh_connection_tests_internal $protocol $id1 $id2 $port
     if [ "$?" != "0" ]; then
-        echo -e "$protocol test VM $id1 ---> VM $id2 FAIL (1)"
-        return
+        fail "$protocol test VM $id1 ---> VM $id2 FAIL (1)"
     fi
 
     ssh_connection_test_file $id2 $protocol
     if [ "$?" == "0" ]; then
         echo -e "$protocol test VM $id1 ---> VM $id2 OK"
     else
-        echo -e "$protocol test VM $id1 ---> VM $id2 FAIL"
-        RETURN_CODE=1
+        fail "$protocol test VM $id1 ---> VM $id2 FAIL"
     fi
-    set -e
+
     ssh_clean_connection $id1 $id2
     return $RETURN_CODE
 }
@@ -360,30 +331,26 @@ function ssh_no_connection_test {
     id2=$3
     port=$4
 
-    set +e
     ssh_connection_tests_internal $protocol $id1 $id2 $port
     if [ "$?" != "0" ]; then
-        echo -e "$protocol test VM $id1 -/-> VM $id2 FAIL (1)"
-        return
+        fail "$protocol test VM $id1 -/-> VM $id2 FAIL (1)"
     fi
     if [ "$protocol" == "sctp" ]; then
         ssh_connection_test_file $id2 $protocol
         if [ "$?" == "0" ]; then
-            echo -e "$protocol test VM $id1 -/-> VM $id2 FAIL"
-            RETURN_CODE=1
+            fail "$protocol test VM $id1 -/-> VM $id2 FAIL"
         else
             echo -e "$protocol test VM $id1 -/-> VM $id2 OK"
         fi
     else
         ssh_run $id2 [ -s "/tmp/test" ]
         if [ "$?" == "0" ]; then
-            echo -e "$protocol test VM $id1 -/-> VM $id2 FAIL"
-            RETURN_CODE=1
+            fail "$protocol test VM $id1 -/-> VM $id2 FAIL"
         else
             echo -e "$protocol test VM $id1 -/-> VM $id2 OK"
         fi
     fi
-    set -e
+
     ssh_clean_connection $id1 $id2
     return $RETURN_CODE
 }
@@ -435,7 +402,7 @@ function qemu_start {
     CMD="sudo qemu-system-x86_64 -netdev user,id=network0,hostfwd=tcp::500${id}-:22 -device e1000,netdev=network0 -m 124M -enable-kvm -chardev socket,id=char0,path=$SOCKET_PATH -netdev type=vhost-user,id=mynet1,chardev=char0,vhostforce -device virtio-net-pci,csum=off,gso=off,mac=$MAC,netdev=mynet1 -object memory-backend-file,id=mem,size=124M,mem-path=/mnt/huge,share=on -numa node,memdev=mem -mem-prealloc -drive file=$IMG_PATH -snapshot -nographic"
     exec $CMD &> $BUTTERFLY_BUILD_ROOT/qemu_${id}_output &
     pid=$!
-    set +e
+
     echo "hello" | nc -w 1  127.0.0.1 500$id &> /dev/null
     TEST=$?
     MAX_TEST=0
@@ -446,12 +413,10 @@ function qemu_start {
         MAX_TEST=$(($MAX_TEST + 1))
         sleep 0.2
     done
-    set -e
+
     sudo kill -s 0 $pid &> /dev/null
     if [ $? -ne 0 ]; then
-        echo "failed to start qemu, check qemu_${id}_output file"
-        clean_all
-        exit 1
+        fail "failed to start qemu, check qemu_${id}_output file"
     fi
     qemu_pids["$id"]=$pid
 
@@ -522,9 +487,7 @@ function server_start_options {
     pid=$!
     sudo kill -s 0 $pid
     if [ $? -ne 0 ]; then
-        echo "failed to start butterfly, check butterflyd_${id}_output file"
-        clean_all
-        exit 1
+        fail "failed to start butterfly, check butterflyd_${id}_output file"
     fi
 
     server_pids["$id"]=$pid
@@ -548,9 +511,7 @@ function network_connect {
     sleep 0.2
     sudo kill -s 0 $pid
     if [ $? -ne 0 ]; then
-        echo "failed connect but$id1 and but$id2"
-        clean_all
-        exit 1
+        fail "failed connect but$id1 and but$id2"
     fi
     socat_pids["$id1$id2"]=$pid
     sudo ip link set dev but$id1 mtu 2000
@@ -592,9 +553,7 @@ function request {
     ret=$?
     rm $f
     if [ ! "$ret" == "0" ]; then
-        echo "client failed to send message to butterfly $but_id"
-        clean_all
-        exit 1
+        fail "client failed to send message to butterfly $but_id"
     fi
 }
 
@@ -603,14 +562,11 @@ function cli {
     excepted_result=$2
     opts=${@:3}
     echo "[butterfly-$but_id] cli run $opts"
-    set +e
+
     $BUTTERFLY_BUILD_ROOT/api/client/butterfly $opts -e tcp://127.0.0.1:876$but_id &> $BUTTERFLY_BUILD_ROOT/cli_output
     if [ ! "$?" == "$excepted_result" ]; then
-        echo "cli run failed, check cli_output file"
-        clean_all
-        exit 1
+        fail "cli run failed, check cli_output file"
     fi
-    set -e
 }
 
 function nic_add_noip {
@@ -659,7 +615,7 @@ function nic_add {
     sg_list=${@:4}
 
     echo "[butterfly-$but_id] add nic $nic_id with vni $vni"
- 
+
     cli $but_id 0 nic add --id "nic-$nic_id" --mac "52:54:00:12:34:0$nic_id" --vni $vni --ip "42.0.0.$nic_id" --enable-antispoof
     sleep 1
 
@@ -669,9 +625,7 @@ function nic_add {
     sleep 1
 
     if ! test -e /tmp/qemu-vhost-nic-$nic_id ; then
-        echo "client failed: we should have a socket in /tmp/qemu-vhost-nic-$nic_id"
-        clean_all
-        exit 1
+        fail "client failed: we should have a socket in /tmp/qemu-vhost-nic-$nic_id"
     fi
 }
 
@@ -691,9 +645,7 @@ function nic_add6 {
     sleep 0.3
 
     if ! test -e /tmp/qemu-vhost-nic-$nic_id ; then
-        echo "client failed: we should have a socket in /tmp/qemu-vhost-nic-$nic_id"
-        clean_all
-        exit 1
+        fail "client failed: we should have a socket in /tmp/qemu-vhost-nic-$nic_id"
     fi
 }
 
@@ -710,9 +662,7 @@ function nic_add_bypass {
     sleep 0.3
 
     if ! test -e /tmp/qemu-vhost-nic-$nic_id ; then
-        echo "client failed: we should have a socket in /tmp/qemu-vhost-nic-$nic_id"
-        clean_all
-        exit 1
+        fail "client failed: we should have a socket in /tmp/qemu-vhost-nic-$nic_id"
     fi
 }
 
@@ -729,7 +679,7 @@ function sg_rule_add_all_open {
     but_id=$1
     sg=$2
     echo "[butterfly-$but_id] add rule all open in $sg"
-    
+
     cli $but_id 0 sg rule add $sg --dir in --ip-proto all --cidr 0.0.0.0/0
     cli $but_id 0 sg rule add $sg --dir in --ip-proto all --cidr ::0/0
 }
@@ -751,7 +701,7 @@ function sg_rule_add_ip_and_port {
     port=$5
     sg=$6
     echo "[butterfly-$but_id] add rule $protocol port $port ip $ip/$mask_size in $sg"
-    cli $but_id 0 sg rule add $sg --dir in --ip-proto $protocol --port-start $port --port-end $port --cidr $ip/$mask_size 
+    cli $but_id 0 sg rule add $sg --dir in --ip-proto $protocol --port-start $port --port-end $port --cidr $ip/$mask_size
 }
 
 function sg_rule_del_ip_and_port {
@@ -803,7 +753,7 @@ function sg_rule_add_ip {
     ip=$2
     mask_size=$3
     sg=$4
-    
+
     echo "[butterfly-$but_id] add rule to $sg: allow $ip/$mask_size on all protocols"
 
     cli $but_id 0 sg rule add $sg --dir in --ip-proto -1 --cidr $ip/$mask_size
@@ -814,7 +764,7 @@ function sg_rule_del_ip {
     ip=$2
     mask_size=$3
     sg=$4
-    
+
     echo "[butterfly-$but_id] delete rule on $sg: allow $ip/$mask_size on all protocols"
     f=/tmp/butterfly-client.req
 
@@ -1059,8 +1009,7 @@ function sg_rule_del_port_open {
     elif [ "$protocol" == "sctp" ]; then
         protocol=132
     else
-        echo -e "protocol $protocol not supported by sg_rule_del_port_open"
-        RETURN_CODE=1
+        fail "protocol $protocol not supported by sg_rule_del_port_open"
     fi
     f=/tmp/butterfly.req
 
@@ -1200,9 +1149,17 @@ function clean_pcaps {
     sudo rm -rf /tmp/butterfly-*.pcap
 }
 function clean_all {
-    sudo killall -9 butterflyd butterfly qemu-system-x86_64 socat &> /dev/null || true
+    sudo killall butterflyd butterfly qemu-system-x86_64 socat &> /dev/null
+    sleep 0.5
+    sudo killall -9 butterflyd butterfly qemu-system-x86_64 socat &> /dev/null
     sudo rm -rf /tmp/*vhost* /dev/hugepages/* /mnt/huge/*  &> /dev/null
     sleep 0.5
+}
+
+function fail {
+    echo $1
+    clean_all
+    exit 1
 }
 
 if [ "$BUTTERFLY_BUILD_ROOT" = "-h" ] || [ "$BUTTERFLY_BUILD_ROOT" = "--help" ] ||

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -66,7 +66,7 @@ function ssh_ping_ip {
 
     ssh_run $id ping -c 1 -W 2 -I $src $dst &> /dev/null
     if [ $? -ne 0 ]; then
-	fail "ping on VM $id: $src ---> $dst FAIL"
+        fail "ping on VM $id: $src ---> $dst FAIL"
     else
         echo "ping on VM $id: $src ---> $dst OK"
     fi
@@ -81,7 +81,7 @@ function ssh_no_ping_ip {
     if [ $? -ne 0 ]; then
         echo "ping on VM $id: $src -/-> $dst OK"
     else
-	fail "ping on VM $id: $src -/-> $dst FAIL"
+        fail "ping on VM $id: $src -/-> $dst FAIL"
     fi
 }
 
@@ -92,7 +92,7 @@ function ssh_ping_ip6 {
 
     ssh_run $id ping6 -c 1 -W 2 -I $src $dst &> /dev/null
     if [ $? -ne 0 ]; then
-	fail "ping6 on VM $id: $src ---> $dst FAIL"
+        fail "ping6 on VM $id: $src ---> $dst FAIL"
     else
         echo "ping6 on VM $id: $src ---> $dst OK"
     fi
@@ -107,7 +107,7 @@ function ssh_no_ping_ip6 {
     if [ $? -ne 0 ]; then
         echo "ping on VM $id: $src -/-> $dst OK"
     else
-	fail "ping6 on VM $id: $src -/-> $dst FAIL"
+        fail "ping6 on VM $id: $src -/-> $dst FAIL"
     fi
 }
 
@@ -391,6 +391,68 @@ function qemu_del_ipv6 {
     done
 }
 
+function qemu_start_async {
+    qemu_start $1 $2 &
+}
+
+
+function qemus_wait {
+    if [ "$#" -eq 0 ]; then
+        return 0
+    fi
+    qemu_wait $1
+    shift 1
+    qemus_wait $@
+}
+
+function qemus_start_ {
+    if [ "$#" -eq 0 ]; then
+        return 0
+    fi
+    qemu_start_async $1
+    shift 1
+    qemus_start_ $@
+}
+
+function qemus_start {
+    qemus_start_ $@
+    qemus_wait $@
+}
+
+function qemu_wait_pid {
+    if [ ! -f "$BUTTERFLY_BUILD_ROOT/qemu_pids$id" ]; then
+        if [ $2 == 0 ]; then
+            return 0
+        fi
+        sleep 1
+        num=$(($2 - 1))
+        qemu_wait_pid $1 $num
+        return $ret
+    fi
+    return 1
+}
+
+function qemu_wait {
+    id=$1
+    echo "hello" | nc -w 1  127.0.0.1 500$id &> /dev/null
+    TEST=$?
+    MAX_TEST=0
+    while  [ $TEST -ne 0 -a $MAX_TEST -ne 20 ]
+    do
+        echo "hello" | nc -w 1  127.0.0.1 500$id &> /dev/null
+        TEST=$?
+        MAX_TEST=$(($MAX_TEST + 1))
+        sleep 0.2
+    done
+
+    qemu_wait_pid $id 30
+    if [ ! $? ]; then
+        fail "qemu $id starting timeout"
+        return
+    fi
+    qemu_pids["$id"]=$(< $BUTTERFLY_BUILD_ROOT/qemu_pids$id)
+}
+
 function qemu_start {
     id=$1
     ip=$2
@@ -465,12 +527,24 @@ function qemu_start {
 
     ssh_run $id pacman -Sy nmap --noconfirm &>/dev/null
     ssh_run $id pacman -Sy lksctp-tools --noconfirm &>/dev/null
+    echo $pid > $BUTTERFLY_BUILD_ROOT/qemu_pids$id
 }
 
 function qemu_stop {
     id=$1
-    echo "stopping VM $id"
+    rm -vf $BUTTERFLY_BUILD_ROOT/qemu_pids$id
+    echo "stopping VM $id pid: ${qemu_pids[$id]}"
     sudo kill -9 $(ps --ppid ${qemu_pids[$id]} -o pid=) &> /dev/null
+    sleep 0.3
+}
+
+function qemus_stop {
+    if [ "$#" -eq 0 ]; then
+        return 0
+    fi
+    qemu_stop $1
+    shift 1
+    qemus_stop $@
 }
 
 function server_start {
@@ -1154,6 +1228,7 @@ function clean_all {
     sudo killall -9 butterflyd butterfly qemu-system-x86_64 socat &> /dev/null
     sudo rm -rf /tmp/*vhost* /dev/hugepages/* /mnt/huge/*  &> /dev/null
     sleep 0.5
+    rm -rvf $BUTTERFLY_BUILD_ROOT/qemu_pids*
 }
 
 function fail {

--- a/tests/scenario_00/test.sh
+++ b/tests/scenario_00/test.sh
@@ -8,10 +8,7 @@ network_connect 0 1
 server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
-qemu_start_async 1
-qemu_start_async 2
-qemu_wait 2
-qemu_wait 1
+qemus_start 1 2
 ssh_no_ping 1 2
 ssh_no_ping 2 1
 sg_rule_add_all_open 0 sg-1
@@ -26,8 +23,7 @@ ssh_ping 2 1
 sg_rule_del_icmp 0 sg-1
 ssh_no_ping 1 2
 ssh_no_ping 2 1
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 server_stop 0
 network_disconnect 0 1
 return_result

--- a/tests/scenario_00/test.sh
+++ b/tests/scenario_00/test.sh
@@ -8,8 +8,10 @@ network_connect 0 1
 server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
-qemu_start 1
-qemu_start 2
+qemu_start_async 1
+qemu_start_async 2
+qemu_wait 2
+qemu_wait 1
 ssh_no_ping 1 2
 ssh_no_ping 2 1
 sg_rule_add_all_open 0 sg-1

--- a/tests/scenario_01/test.sh
+++ b/tests/scenario_01/test.sh
@@ -11,8 +11,9 @@ nic_add 0 1 42 sg-1
 nic_add 1 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
 sg_rule_add_all_open 1 sg-1
-qemu_start 1
-qemu_start 2
+qemu_start_async 1
+qemu_start_async 2
+qemus_wait 1 2
 ssh_ping 1 2
 ssh_ping 2 1
 qemu_stop 1

--- a/tests/scenario_02/test.sh
+++ b/tests/scenario_02/test.sh
@@ -13,10 +13,11 @@ nic_add 1 3 42 sg-1
 nic_add 1 4 42 sg-1
 sg_rule_add_all_open 0 sg-1
 sg_rule_add_all_open 1 sg-1
-qemu_start 1
-qemu_start 2
-qemu_start 3
-qemu_start 4
+qemu_start_async 1
+qemu_start_async 2
+qemu_start_async 3
+qemu_start_async 4
+qemus_wait 4 3 2 1
 ssh_ping 1 2
 ssh_ping 1 3
 ssh_ping 1 4

--- a/tests/scenario_03/test.sh
+++ b/tests/scenario_03/test.sh
@@ -13,10 +13,11 @@ nic_add 1 3 1337 sg-1
 nic_add 1 4 42 sg-1
 sg_rule_add_all_open 0 sg-1
 sg_rule_add_all_open 1 sg-1
-qemu_start 1
-qemu_start 2
-qemu_start 3
-qemu_start 4
+qemu_start_async 1
+qemu_start_async 2
+qemu_start_async 3
+qemu_start_async 4
+qemus_wait 1 2 3 4
 ssh_no_ping 1 2
 ssh_no_ping 1 3
 ssh_ping 1 4

--- a/tests/scenario_04/test.sh
+++ b/tests/scenario_04/test.sh
@@ -9,8 +9,9 @@ server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemu_start_async 1
+qemu_start_async 2
+qemus_wait 1 2
 ssh_ping 1 2
 ssh_ping 2 1
 qemu_stop 1

--- a/tests/scenario_06/test.sh
+++ b/tests/scenario_06/test.sh
@@ -10,80 +10,70 @@ server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 ssh_ping 1 2
 ssh_ping 2 1
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 nic_del 0 1
 nic_del 0 2
 
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 ssh_ping 1 2
 ssh_ping 2 1
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 nic_del 0 1
 nic_del 0 2
+
+sleep 4
 
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 ssh_ping 1 2
 ssh_ping 2 1
 nic_del 0 1
 nic_del 0 2
 ssh_no_ping 1 2
 ssh_no_ping 2 1
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 ssh_ping 1 2
 ssh_ping 2 1
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 nic_del 0 1
 nic_del 0 2
 
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 ssh_ping 1 2
 ssh_ping 2 1
 nic_del 0 1
 nic_del 0 2
 ssh_no_ping 1 2
 ssh_no_ping 2 1
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 ssh_ping 1 2
 ssh_ping 2 1
 nic_del 0 1
 nic_del 0 2
 ssh_no_ping 1 2
 ssh_no_ping 2 1
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 
 server_stop 0
 network_disconnect 0 1

--- a/tests/scenario_07/test.sh
+++ b/tests/scenario_07/test.sh
@@ -9,8 +9,7 @@ server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 ssh_connection_test udp 2 1 1234
 ssh_connection_test udp 1 2 1234
 qemu_stop 1
@@ -18,4 +17,3 @@ qemu_stop 2
 server_stop 0
 network_disconnect 0 1
 return_result
-

--- a/tests/scenario_08/test.sh
+++ b/tests/scenario_08/test.sh
@@ -9,8 +9,9 @@ server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 1337 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemu_start_async 1
+qemu_start_async 2
+qemus_wait 1 2
 ssh_no_connection_test udp 2 1 2345
 ssh_no_connection_test udp 1 2 4523
 qemu_stop 1

--- a/tests/scenario_09/test.sh
+++ b/tests/scenario_09/test.sh
@@ -9,8 +9,9 @@ server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemu_start_async 1
+qemu_start_async 2
+qemus_wait 1 2
 ssh_connection_test tcp 2 1 4045
 ssh_connection_test tcp 1 2 1445
 qemu_stop 1

--- a/tests/scenario_10/test.sh
+++ b/tests/scenario_10/test.sh
@@ -9,8 +9,9 @@ server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 1337 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemu_start_async 1
+qemu_start_async 2
+qemus_wait 1 2
 ssh_no_connection_test tcp 2 1 2456
 ssh_no_connection_test tcp 1 2 2435
 qemu_stop 1

--- a/tests/scenario_11/test.sh
+++ b/tests/scenario_11/test.sh
@@ -13,10 +13,11 @@ nic_add 1 3 42 sg-1
 nic_add 1 4 42 sg-1
 sg_rule_add_all_open 0 sg-1
 sg_rule_add_all_open 1 sg-1
-qemu_start 1
-qemu_start 2
-qemu_start 3
-qemu_start 4
+qemu_start_async 1
+qemu_start_async 2
+qemu_start_async 3
+qemu_start_async 4
+qemus_wait 1 2 3 4
 ssh_connection_test udp 1 2 1234
 ssh_connection_test udp 1 3 5554
 ssh_connection_test udp 1 4 4123

--- a/tests/scenario_12/test.sh
+++ b/tests/scenario_12/test.sh
@@ -13,10 +13,11 @@ nic_add 1 3 1337 sg-1
 nic_add 1 4 42 sg-1
 sg_rule_add_all_open 0 sg-1
 sg_rule_add_all_open 1 sg-1
-qemu_start 1
-qemu_start 2
-qemu_start 3
-qemu_start 4
+qemu_start_async 1
+qemu_start_async 2
+qemu_start_async 3
+qemu_start_async 4
+qemus_wait 1 2 3 4
 ssh_no_connection_test udp 1 2 5054
 ssh_no_connection_test udp 1 3 5034
 ssh_connection_test udp 1 4 5050

--- a/tests/scenario_13/test.sh
+++ b/tests/scenario_13/test.sh
@@ -13,10 +13,11 @@ nic_add 1 3 42 sg-1
 nic_add 1 4 42 sg-1
 sg_rule_add_all_open 0 sg-1
 sg_rule_add_all_open 1 sg-1
-qemu_start 1
-qemu_start 2
-qemu_start 3
-qemu_start 4
+qemu_start_async 1
+qemu_start_async 2
+qemu_start_async 3
+qemu_start_async 4
+qemus_wait 1 2 3 4
 ssh_connection_test tcp 1 2 1234
 ssh_connection_test tcp 1 3 5554
 ssh_connection_test tcp 1 4 4123

--- a/tests/scenario_14/test.sh
+++ b/tests/scenario_14/test.sh
@@ -13,10 +13,11 @@ nic_add 1 3 1337 sg-1
 nic_add 1 4 42 sg-1
 sg_rule_add_all_open 0 sg-1
 sg_rule_add_all_open 1 sg-1
-qemu_start 1
-qemu_start 2
-qemu_start 3
-qemu_start 4
+qemu_start_async 1
+qemu_start_async 2
+qemu_start_async 3
+qemu_start_async 4
+qemus_wait 1 2 3 4
 ssh_no_connection_test tcp 1 2 5054
 ssh_no_connection_test tcp 1 3 5034
 ssh_connection_test tcp 1 4 5050

--- a/tests/scenario_15/test.sh
+++ b/tests/scenario_15/test.sh
@@ -9,8 +9,9 @@ server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 sg_rule_add_port_open udp 0 5554 sg-1
-qemu_start 1
-qemu_start 2
+qemu_start_async 1
+qemu_start_async 2
+qemus_wait 1 2
 ssh_connection_test udp 1 2 5554
 ssh_connection_test udp 2 1 5554
 ssh_no_connection_test tcp 2 1 4445

--- a/tests/scenario_16/test.sh
+++ b/tests/scenario_16/test.sh
@@ -9,8 +9,9 @@ server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 sg_rule_add_port_open tcp 0 4454 sg-1
-qemu_start 1
-qemu_start 2
+qemu_start_async 1
+qemu_start_async 2
+qemus_wait 2 1
 ssh_connection_test tcp 1 2 4454
 ssh_connection_test tcp 2 1 4454
 ssh_no_connection_test tcp 2 1 4452

--- a/tests/scenario_17/test.sh
+++ b/tests/scenario_17/test.sh
@@ -9,8 +9,9 @@ server_start 0
 nic_add 0 1 42
 nic_add 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemu_start_async 1
+qemu_start_async 2
+qemus_wait 2 1
 ssh_connection_test udp 1 2 5543
 ssh_connection_test tcp 1 2 1243
 ssh_no_connection_test udp 2 1 1254

--- a/tests/scenario_18/test.sh
+++ b/tests/scenario_18/test.sh
@@ -9,8 +9,9 @@ server_start 0
 nic_add 0 1 42
 nic_add 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemu_start_async 1
+qemu_start_async 2
+qemus_wait 1 2
 ssh_connection_test udp 1 2 1243
 ssh_connection_test tcp 1 2 5543
 ssh_no_connection_test udp 2 1 1234

--- a/tests/scenario_19/test.sh
+++ b/tests/scenario_19/test.sh
@@ -8,8 +8,9 @@ network_connect 0 1
 server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
-qemu_start 1
-qemu_start 2
+qemu_start_async 1
+qemu_start_async 2
+qemus_wait 1 2
 ssh_no_connection_test udp 1 2 5554
 ssh_no_connection_test udp 2 1 5554
 ssh_no_connection_test tcp 2 1 4445

--- a/tests/scenario_20/test.sh
+++ b/tests/scenario_20/test.sh
@@ -9,9 +9,10 @@ server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 nic_add 0 3 42 sg-1
-qemu_start 1
-qemu_start 2
-qemu_start 3
+qemu_start_async 1
+qemu_start_async 2
+qemu_start_async 3
+qemus_wait 1 2 3
 
 ssh_no_connection_test udp 3 1 8000
 ssh_no_connection_test udp 3 2 8000

--- a/tests/scenario_21/test.sh
+++ b/tests/scenario_21/test.sh
@@ -9,8 +9,7 @@ server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 ssh_iperf_tcp 1 2
 ssh_iperf_tcp 2 1
 ssh_iperf_udp 1 2
@@ -19,8 +18,7 @@ ssh_iperf3_tcp 1 2
 ssh_iperf3_tcp 2 1
 ssh_iperf3_udp 1 2
 ssh_iperf3_udp 2 1
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 server_stop 0
 network_disconnect 0 1
 return_result

--- a/tests/scenario_22/test.sh
+++ b/tests/scenario_22/test.sh
@@ -11,8 +11,7 @@ nic_add 0 1 42 sg-1
 nic_add 1 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
 sg_rule_add_all_open 1 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 ssh_iperf_tcp 1 2
 ssh_iperf_tcp 2 1
 ssh_iperf_udp 1 2
@@ -21,8 +20,7 @@ ssh_iperf3_tcp 1 2
 ssh_iperf3_tcp 2 1
 ssh_iperf3_udp 1 2
 ssh_iperf3_udp 2 1
-qemu_stop 1
-qemu_stop 2
+qemu_stop 1 2
 server_stop 0
 server_stop 1
 network_disconnect 0 1

--- a/tests/scenario_23/test.sh
+++ b/tests/scenario_23/test.sh
@@ -8,8 +8,7 @@ network_connect 0 1
 server_start 0
 nic_add 0 1 42
 nic_add 0 2 42
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 
 ssh_no_connection_test tcp 2 1 4454
 ssh_no_connection_test tcp 1 2 4454
@@ -38,8 +37,7 @@ for i in {1..3}; do
     ssh_no_connection_test udp 2 1 5554
     ssh_no_connection_test udp 1 2 5554
 done
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 server_stop 0
 network_disconnect 0 1
 return_result

--- a/tests/scenario_24/test.sh
+++ b/tests/scenario_24/test.sh
@@ -9,8 +9,7 @@ server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 for i in {1..50}; do
     ssh_connection_test udp 1 2 1234
     ssh_connection_test udp 2 1 1234
@@ -20,8 +19,7 @@ for i in {1..50}; do
     ssh_connection_test tcp 1 2 1234
     ssh_connection_test tcp 2 1 1234
 done
-qemu_stop 1
-qemu_stop 2
+qemu_stop 1 2
 server_stop 0
 network_disconnect 0 1
 return_result

--- a/tests/scenario_25/test.sh
+++ b/tests/scenario_25/test.sh
@@ -8,8 +8,7 @@ network_connect 0 1
 server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 
 for i in {1..10}; do
     ssh_no_connection_test udp 1 2 6000
@@ -29,8 +28,7 @@ for i in {1..10}; do
 
     sg_del 0 sg-1
 done
-qemu_stop 1
-qemu_stop 2
+qemu_stop 1 2
 server_stop 0
 network_disconnect 0 1
 return_result

--- a/tests/scenario_26/test.sh
+++ b/tests/scenario_26/test.sh
@@ -8,8 +8,7 @@ network_connect 0 1
 server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 
 for i in {1..10}; do
     ssh_no_connection_test udp 1 2 4054
@@ -25,8 +24,7 @@ for i in {1..10}; do
 
     sg_add sg-1 0
 done
-qemu_stop 1
-qemu_stop 2
+qemu_stop 1 2
 server_stop 0
 network_disconnect 0 1
 return_result

--- a/tests/scenario_27/test.sh
+++ b/tests/scenario_27/test.sh
@@ -8,8 +8,7 @@ network_connect 0 1
 server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-2
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 sg_member_add 0 sg-1 42.0.0.1
 sg_member_add 0 sg-2 42.0.0.2
 sg_rule_add_with_sg_member udp sg-1 0 8000 sg-1
@@ -30,8 +29,7 @@ sg_member_del 0 sg-2 42.0.0.1
 ssh_no_connection_test udp 1 2 9000
 ssh_no_connection_test udp 2 1 8000
 
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 server_stop 0
 network_disconnect 0 1
 return_result

--- a/tests/scenario_28/test.sh
+++ b/tests/scenario_28/test.sh
@@ -8,8 +8,7 @@ network_connect 0 1
 server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 
 ssh_no_ping 1 2
 ssh_no_ping 2 1
@@ -51,8 +50,7 @@ ssh_no_connection_test tcp 1 2 8000
 ssh_connection_test udp 1 2 8000
 ssh_connection_test udp 2 1 8000
 
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 server_stop 0
 network_disconnect 0 1
 return_result

--- a/tests/scenario_29/test.sh
+++ b/tests/scenario_29/test.sh
@@ -9,9 +9,7 @@ server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 nic_add 0 3 42 sg-2
-qemu_start 1
-qemu_start 2
-qemu_start 3
+qemus_start 1 2 3
 
 sg_member_add 0 sg-1 42.0.0.1
 sg_member_add 0 sg-1 42.0.0.2
@@ -41,9 +39,7 @@ ssh_no_connection_test udp 2 3 8000
 ssh_no_connection_test udp 1 2 8000
 ssh_no_connection_test udp 2 1 8000
 
-qemu_stop 1
-qemu_stop 2
-qemu_stop 3
+qemus_stop 1 2 3
 server_stop 0
 network_disconnect 0 1
 return_result

--- a/tests/scenario_30/test.sh
+++ b/tests/scenario_30/test.sh
@@ -8,8 +8,7 @@ network_connect 0 1
 server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-2
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 
 sg_member_add 0 sg-1 42.0.0.1
 sg_rule_add_with_sg_member udp sg-2 0 8000 sg-1
@@ -24,8 +23,7 @@ sg_member_add 0 sg-1 42.0.0.1
 ssh_connection_test udp 1 2 8000
 ssh_no_connection_test udp 2 1 8000
 
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 server_stop 0
 network_disconnect 0 1
 return_result

--- a/tests/scenario_31/test.sh
+++ b/tests/scenario_31/test.sh
@@ -9,8 +9,7 @@ server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42
 sg_rule_add_port_open udp 0 8000 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 
 sg_rule_add_port_open udp 0 9000 sg-2
 ssh_connection_test udp 2 1 8000
@@ -29,8 +28,7 @@ remove_sg_from_nic 0 1
 ssh_no_connection_test udp 2 1 8000
 ssh_no_connection_test udp 2 1 9000
 
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 server_stop 0
 network_disconnect 0 1
 return_result

--- a/tests/scenario_32/test.sh
+++ b/tests/scenario_32/test.sh
@@ -11,16 +11,16 @@ nic_add 0 1 42 sg-1
 nic_add 1 2 42 sg-1
 sg_rule_add_dhcp 0 sg-1
 sg_rule_add_dhcp 1 sg-1
-qemu_start 1 dhcp-server
-qemu_start 2 dhcp-client
+qemu_start_async 1 dhcp-server
+qemu_start_async 2 dhcp-client
+qemus_wait 1 2
 ssh_no_ping 1 2
 ssh_no_ping 2 1
 sg_rule_add_icmp 0 sg-1
 sg_rule_add_icmp 1 sg-1
 ssh_ping 1 2
 ssh_ping 2 1
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 server_stop 0
 server_stop 1
 network_disconnect 0 1

--- a/tests/scenario_33/test.sh
+++ b/tests/scenario_33/test.sh
@@ -8,8 +8,7 @@ network_connect 0 1
 server_start 0
 nic_add6 0 1 42 sg-1
 nic_add6 0 2 42 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 
 ssh_no_ping6 1 2
 ssh_no_ping6 2 1
@@ -44,8 +43,7 @@ ssh_no_connection_test tcp6 2 1 8000
 ssh_no_connection_test udp6 1 2 8000
 ssh_no_connection_test udp6 2 1 8000
 
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 server_stop 0
 network_disconnect 0 1
 return_result

--- a/tests/scenario_34/test.sh
+++ b/tests/scenario_34/test.sh
@@ -9,8 +9,7 @@ server_start 0
 server_start 1
 nic_add 0 1 42 sg-1
 nic_add 1 2 42 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 
 ssh_no_connection_test sctp 1 2 8000
 ssh_no_connection_test sctp 2 1 8000
@@ -25,8 +24,7 @@ sg_rule_del_all_open 1 sg-1
 ssh_no_connection_test sctp 1 2 8000
 ssh_no_connection_test sctp 2 1 8000
 
-qemu_stop 1
-qemu_stop 2
+qemus_stop 1 2
 server_stop 0
 server_stop 1
 network_disconnect 0 1

--- a/tests/scenario_35/test.sh
+++ b/tests/scenario_35/test.sh
@@ -9,8 +9,7 @@ server_start 0
 nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 ssh_ping 1 2
 ssh_ping 2 1
 nic_del 0 1
@@ -21,10 +20,8 @@ nic_add 0 1 42 sg-1
 nic_add 0 2 42 sg-1
 ssh_no_ping 1 2
 ssh_no_ping 2 1
-qemu_stop 1
-qemu_stop 2
-qemu_start 1
-qemu_start 2
+qemus_stop 1 2
+qemus_start 1 2
 ssh_ping 1 2
 ssh_ping 2 1
 server_stop 0

--- a/tests/scenario_37/test.sh
+++ b/tests/scenario_37/test.sh
@@ -9,8 +9,9 @@ server_start 0
 nic_add_noip 0 1 42 sg-1
 nic_add_noip 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1 noip
-qemu_start 2 noip
+qemu_start_async 1 noip
+qemu_start_async 2 noip
+qemus_wait 1 2
 
 a1=42.0.0.1
 a2=42.0.0.2

--- a/tests/scenario_38/test.sh
+++ b/tests/scenario_38/test.sh
@@ -9,8 +9,9 @@ server_start 0
 nic_add_noip 0 1 42 sg-1
 nic_add_noip 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1 noip
-qemu_start 2 noip
+qemu_start_async 1 noip
+qemu_start_async 2 noip
+qemus_wait 1 2
 
 a1=2001:db8:2000:aff0::1
 a2=2001:db8:2000:aff0::2

--- a/tests/scenario_39/test.sh
+++ b/tests/scenario_39/test.sh
@@ -9,8 +9,9 @@ server_start 0
 nic_add_noip 0 1 42 sg-1
 nic_add_noip 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1 noip
-qemu_start 2 noip
+qemu_start_async 1 noip
+qemu_start_async 2 noip
+qemus_wait 1 2
 
 a1=42.0.0.1
 a2=42.0.0.2

--- a/tests/scenario_40/test.sh
+++ b/tests/scenario_40/test.sh
@@ -9,8 +9,9 @@ server_start 0
 nic_add_noip 0 1 42 sg-1
 nic_add_noip 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1 noip
-qemu_start 2 noip
+qemu_start_async 1 noip
+qemu_start_async 2 noip
+qemus_wait 1 2
 
 a1=42.0.0.1
 a2=42.0.0.2

--- a/tests/scenario_41/test.sh
+++ b/tests/scenario_41/test.sh
@@ -9,8 +9,9 @@ server_start 0
 nic_add_noip 0 1 42 sg-1
 nic_add_noip 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1 noip
-qemu_start 2 noip
+qemu_start_async 1 noip
+qemu_start_async 2 noip
+qemus_wait 1 2
 
 a1=42.0.0.1
 b1=42.0.0.2

--- a/tests/scenario_42/test.sh
+++ b/tests/scenario_42/test.sh
@@ -9,8 +9,7 @@ server_start 0
 nic_add 0 1 42 sg-1
 nic_add_noip 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1
-qemu_start 2
+qemus_start 1 2
 
 for i in $(seq 1 10); do
     ssh_no_ping 1 2
@@ -21,8 +20,7 @@ for i in $(seq 1 10); do
     sleep 1
 done
 
-qemu_stop 2
-qemu_stop 1
+qemus_stop 2 1
 server_stop 0
 network_disconnect 0 1
 return_result

--- a/tests/scenario_43/test.sh
+++ b/tests/scenario_43/test.sh
@@ -9,8 +9,9 @@ server_start 0
 nic_add_noip 0 1 42 sg-1
 nic_add_noip 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1 noip
-qemu_start 2 noip
+qemu_start_async 1 noip
+qemu_start_async 2 noip
+qemus_wait 1 2
 
 a1=42.0.0.1
 b1=42.0.0.2

--- a/tests/scenario_44/test.sh
+++ b/tests/scenario_44/test.sh
@@ -9,8 +9,9 @@ server_start 0
 nic_add_noip 0 1 42 sg-1
 nic_add_noip 0 2 42 sg-1
 sg_rule_add_all_open 0 sg-1
-qemu_start 1 noip
-qemu_start 2 noip
+qemu_start_async 1 noip
+qemu_start_async 2 noip
+qemus_wait 1 2
 
 a1=42.0.0.1
 b1=42.0.0.2

--- a/tests/scenario_45/test.sh
+++ b/tests/scenario_45/test.sh
@@ -28,8 +28,7 @@ for big in \
     server_start_options 1 $_server_start_options
     nic_add 0 1 42 sg-1
     nic_add 1 2 42 sg-1
-    qemu_start 1
-    qemu_start 2
+    qemus_start 1 2
     sg_rule_add_icmp 0 sg-1
     sg_rule_add_icmp 1 sg-1
     ssh_ping 1 2
@@ -59,8 +58,7 @@ for big in \
     nic_del 0 3
     nic_del 0 4
     ssh_ping 1 2
-    qemu_stop 1
-    qemu_stop 2
+    qemus_stop 1 2
     server_stop 0
     server_stop 1
 


### PR DESCRIPTION
remove set -e/+e, but add a function "fail".

This basically print a error message, clean_all and exit 1, this allow
to controlle the error flow of the tests, and remove ~50 lines of
duplicated code.

The controlle of the error flow is a big plus, as now the tests can fail
only when we think they can fail, so they tests only what we want them to
tests.

remove some trailling-whitespace too

Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>