### PR TITLE
Revert "api/server: fix test failing (this commit did not fix the bug)"

### DIFF
--- a/api/server/graph.cc
+++ b/api/server/graph.cc
@@ -753,7 +753,6 @@ void Graph::LinkSniffer(const app::Nic &nic, Graph::BrickShrPtr n_sniffer) {
         link(g_nic->antispoof, n_sniffer);
         link(n_sniffer, g_nic->vhost);
     }
-    WaitEmptyQueue();
 }
 
 void Graph::EnablePacketTrace(const app::Nic &nic) {
@@ -804,7 +803,6 @@ void Graph::DisablePacketTrace(const app::Nic &nic) {
         g_nic->head = g_nic->antispoof;
         link(g_nic->antispoof, g_nic->vhost);
     }
-    WaitEmptyQueue();
 }
 
 void Graph::NicConfigPacketTrace(const app::Nic &nic, bool is_trace_set) {


### PR DESCRIPTION
This reverts commit 46244dd8ab4610ac0c1ffdb285bb15060a2c9a53.