### PR TITLE
api/server: improve error reporting

### DIFF
--- a/api/server/app.h
+++ b/api/server/app.h
@@ -125,6 +125,7 @@ extern Model model;
 extern Log log;
 extern Graph graph;
 extern pg_error *pg_error;
+
 }  // namespace app
 
 #endif  // API_SERVER_APP_H_

--- a/api/server/model.cc
+++ b/api/server/model.cc
@@ -81,7 +81,7 @@ std::string Cidr::Str() const {
     return address.Str() + "/" + std::to_string(mask_size);
 }
 
-Ip::Ip() {
+Ip::Ip() : broken(false) {
     type_ = Ip::NONE;
     memset(data_, 0, 16);
 }
@@ -139,8 +139,10 @@ bool Ip::Set(std::string a) {
         inet_ntop(AF_INET6, &a6, str, INET6_ADDRSTRLEN);
         ip_ = str;
     } else {
+        broken = true;
         return false;
     }
+    broken = false;
     return true;
 }
 

--- a/api/server/model.h
+++ b/api/server/model.h
@@ -40,6 +40,7 @@ class Ip {
     bool Bytes(uint8_t *data) const;
     bool operator== (const Ip& a) const;
     Ip operator= (const std::string &a);
+    bool broken;
  private:
     std::string ip_;
     type_t type_;


### PR DESCRIPTION
most errors due to wrong argument send to butterfly was report as
"internal error" which isn't very explicit, this patch allow to report
error more properly.

Thgis patch also add a message when IP is wrong
ex: 1270.0.0.1 now print
"can't convert 1270.0.0.1 to IP"

Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>